### PR TITLE
Avoid repeated favorites

### DIFF
--- a/eo.py
+++ b/eo.py
@@ -1,8 +1,9 @@
+# -*- coding: utf-8 -*-
 """
     Here is a wrapper for the *unreleased* electric objects API.
     Built by
-    - Harper Reed (harper@nata2.org) - @harper
-    - Gary Boone (gary.boone@gmail.com) - github.com/GaryBoone
+    • Harper Reed (harper@nata2.org) - @harper
+    • Gary Boone (gary.boone@gmail.com) - github.com/GaryBoone
 
     The Electric Objects API is not yet supported by Electric Objects. It may change or
     stop working at any time.

--- a/eo.py
+++ b/eo.py
@@ -1,8 +1,8 @@
 """
     Here is a wrapper for the *unreleased* electric objects API.
     Built by
-    • Harper Reed (harper@nata2.org) - @harper
-    • Gary Boone (gary.boone@gmail.com) - github.com/GaryBoone
+    - Harper Reed (harper@nata2.org) - @harper
+    - Gary Boone (gary.boone@gmail.com) - github.com/GaryBoone
 
     The Electric Objects API is not yet supported by Electric Objects. It may change or
     stop working at any time.
@@ -25,7 +25,6 @@
 """
 
 from lxml import html
-import json
 import os
 import random
 import requests
@@ -148,11 +147,16 @@ class ElectricObject:
         """
         path = "/api/beta/user/artworks/favorited"
         response = self.make_request(path, method='GET')
-        if not response or response.status_code != requests.codes.ok:
+        if response is None:
             return []
-        html = response.text.encode('utf-8').strip()
-        favorites_json = json.loads(html)
-        return favorites_json
+        elif response.status_code != requests.codes.ok:
+            print "Error in favorites(): HTML response", response.status_code, response.reason
+            return []
+        try:
+            return response.json()
+        except:
+            print "Error in favorites(): unable to parse JSON"
+        return []
 
     def display_random_favorite(self):
         """Retrieve the user's favorites and display one of them randomly.

--- a/eo.py
+++ b/eo.py
@@ -167,13 +167,30 @@ class ElectricObject:
         path = "/api/beta/user/devices"
         return self.make_JSON_request(path, method='GET')
 
+    def choose_random_item(self, items, excluded_id=None):
+        """Return a random item, avoiding the one with the excluded_id, if given.
+        Args:
+            items: a list of Electric Object's artwork objects.
+
+        Returns:
+            An artwork item, which could have the excluded_id if there's only one choice,
+            or [] if the list is empty.
+        """
+        if not items:
+            return []
+        if len(items) == 1:
+            return items[0]
+        if excluded_id:
+            items = [item for item in items if item['artwork']['id'] != excluded_id]
+        return random.choice(items)
+
     def display_random_favorite(self):
-        """Retrieve the user's favorites and display one of them randomly.
+        """Retrieve the user's favorites and displays one of them randomly.
 
         Note that at present, only the first 20 favorites are returned by the API.
 
-        It's possible to choose the same favorite that is already displayed. To avoid that,
-        first request the displayed image and remove it from the favorites list, if present.
+        A truely random choice could be the one already displayed. To avoid that, first
+        request the displayed image and remove it from the favorites list, if present.
 
         Note:
             This function works on the first device if there are multiple devices associated
@@ -186,16 +203,17 @@ class ElectricObject:
         if not devs:
             print "Error in display_random_favorite: no devices returned."
             return 0
-        current_image = devs[0]["reproduction"]["artwork"]["id"]
-        print "current_image =", current_image
+        device_index = 0
+        current_image_id = devs[device_index]['reproduction']['artwork']['id']
 
         favs = self.favorites()
         if favs == []:
             return 0
-        fav = random.choice(favs)
-        media_id = str(fav['artwork']['id'])
-        print media_id
-        return self.display(media_id)
+        fav_item = self.choose_random_item(favs, current_image_id)
+        if not fav_item:
+            return 0
+        fav_id_str = str(fav_item['artwork']['id'])
+        return self.display(fav_id_str)
 
     def set_url(self, url):
         """Set a URL to be on the display.


### PR DESCRIPTION
There's a 5% that displaying a favorite will show the artwork already displayed. Fix by checking what's displayed first and omitting it from the random favorites pool.
