### PR TITLE
Added Python shebang line

### DIFF
--- a/eo.py
+++ b/eo.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
     Here is a wrapper for the *unreleased* electric objects API.


### PR DESCRIPTION
Using launchd to automate running the script returns namespace error without shebang line.
