### PR TITLE
Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Unofficial Electric Objects Python Library
 
 ## Overview
 
-The eo-python demonstrates how to control the Electric Objects EO1 using their *unsupported* beta API and Python. 
+The eo-python demonstrates how to control the Electric Objects EO1 using their *unsupported* API and Python. 
 
 In addition to demonstrating several kinds of API calls, eo-python out-of-the-box will randomly display one of your favorites. 
+
+The code also demonstrates several features of highly-reliable client software, including rate limiting and retries with limits, exponential backoff, and jitter. See below for an explanation of these best practices.
 
 This code was written by [Harper Reed](https://github.com/harperreed) and [Gary Boone](https://github.com/garyboone).
 
@@ -92,6 +94,36 @@ The script is designed to display a new favorite on the EO1 each time it is run.
 #### [Mac OSX only]
 The script eo.py can be configured to run under OSX's launchd facility. Help for launchd can be found on the web. For example, see [launchd.info](http://launchd.info/), which includes examples for the easy-to-use [LaunchControl](http://www.soma-zone.com/LaunchControl/) application.
 
+## Reliability Best Practices
 
-## License ##
+Naively written client code can pose a threat to servers. By failing to consider scaling issues, clients can create overload conditions for servers that lead to request failures, server failures, or even complete service outages. The primary threat arises from large numbers of clients becoming synchronized, making large numbers of server requests simultaneously by chance, or by hammering overloaded servers with retry requests compounding the overload problem. Even a small number of clients can create abusive loads if they all hit servers at the same time. 
+
+As the Electric Objects' API is not officially supported, it may not be provisioned for the kinds of loads unknown Internet clients could create. So it is imperative that clients are well-behaved. This code demonstrates several of the best practices for creating reliable clients that avoid risks of server abuse.
+
+Independent of the Electric Objects API, this code may be useful to coders who want to understand client/server scalability issues including rate limiting, limited retries, exponential backoff, and jitter.
+
+The key issue is that servers can be overloaded by too many simultaneous requests. Correctly written clients avoid overloading the servers by carefully avoiding synchronization and avoiding naive retries on errors. The following techniques are used. Below, we'll talk about a single server, but the principle applies to pools of servers and whole distributed systems, differing only by scale.
+
+#### Asynchrony
+
+Clients often operate on fixed schedules, updating their state periodically such as on the hour. Sensible enough, unless you're the server which now endures a synchronized onslaught of load every hour on the hour. Such a load is easily avoided: client programmers should choose randomized times for updates. At the very least, avoid on-the-hour or on-the-half-hour updates. Avoid wall-clock update times. Prefer every-k hours instead because every-k hours after startup will vary naturally with the client startup time. See also Jitter below.
+
+#### Rate Limiting
+
+The simplest best practice is to avoid making sequences of requests to servers as quickly as possible. Instead, ensure that there is some delay between subsequent requests. As most of the delay is in the network or server response time, it does little good to hit a server as quickly as possible. But spacing out server requests can make a large difference in reliability, allowing the servers to complete more requests without overloading. Just as traffic lights increase car throughout through intersections, rate limited clients increase the chance that their series of requests succeed by reducing the likelihood that the servers drop some requests as they become overloaded.
+
+#### Limited Retries
+
+Because we consider the network to provide unreliable connections, it makes sense to retry a request to a server if it fails. But doing so naively can decrease reliability. As a server becomes overloaded and starts to fail requests, clients retrying their requests will escalate the problem, added more and more requests. Instead, clients should retry only a limited number of times. For many applications, that's fine. In this code, if the client fails to update the artwork, it can just try again later.
+
+#### Exponential Backoff
+
+If a client does retry failed requests, it should not retry immediately. Instead, it should wait an exponentially increasing amount of time between retries. For example, this code waits 4, 8, 16, and 32 seconds, then gives up. That backoff time allows the load on a server to dissipate. As all of the clients notice the problem, they avoid piling onto the failing server. Such a pile-on increases the likelihood of the server failing and worse, spreading its increasing load to the other servers in its pool which having lost one of its servers then has reduced capacity, creating a cascading failure. The solution is for clients to backoff their retries. It has to be exponential because the onset of load will be exponential as more clients add more retries.
+
+#### Jitter
+
+Even exponential backoff isn't quite enough to save our failing server. If all of the clients backoff at the exact same schedule and remain synchronized as they do it, the server will continue to be slammed with a debilitating amount of simultaneous traffic. What could cause such a synchronization? The server failure itself! The solution is again to add variation. If a client has to retry, it should add jitter to the retry schedule. So instead of waiting 4 seconds, it should wait 4 +/- 0.8 seconds, for example. A 20% randomization maintains the exponential backoff schedule while spreading out the requests of the collection of clients that start at the same time.
+
+
+## License
 The code is available at GitHub [HarperReed/eo-python](https://github.com/harperreed/eo-python) under the [MIT license](http://opensource.org/licenses/mit-license.php).

--- a/eo.py
+++ b/eo.py
@@ -169,8 +169,8 @@ class ElectricObject(object):
         if not fav_item:
             return 0
         fav_id = fav_item["artwork"]["id"]
-        self.display(str(fav_id))
-        return fav_id
+        res = self.display(str(fav_id))
+        return fav_id if res else 0
 
     def set_url(self, url):
         """Display the given URL on the first device associated with the signed-in user.
@@ -246,7 +246,7 @@ def setup_logging():
     return logger
 
 
-def new_favorite(eo):
+def show_a_new_favorite(eo):
     """Update the EO1 with a new, randomly selected favorite."""
     logger = logging.getLogger("eo")
     logger.info('Updating favorite')
@@ -300,7 +300,7 @@ def main():
 
     # demo(eo)
 
-    scheduler = Scheduler(SCHEDULE, lambda: new_favorite(eo), schedule_jitter=SCHEDULE_JITTER)
+    scheduler = Scheduler(SCHEDULE, lambda: show_a_new_favorite(eo), schedule_jitter=SCHEDULE_JITTER)
     scheduler.run()
 
 

--- a/eo.py
+++ b/eo.py
@@ -291,6 +291,11 @@ def main():
     setup_logging()
 
     credentials = get_credentials()
+    if credentials["username"] == "" or credentials["password"] == "":
+        logger = logging.getLogger("eo")
+        logger.error("The username or password are blank. See code for how to set them. Exiting.")
+        exit()
+
     eo = ElectricObject(username=credentials["username"], password=credentials["password"])
 
     # demo(eo)

--- a/eo.py
+++ b/eo.py
@@ -299,7 +299,7 @@ def main():
 
     eo = ElectricObject(username=credentials["username"], password=credentials["password"])
 
-    if sys.argv[1] == "--once":
+    if len(sys.argv) > 1 and sys.argv[1] == "--once":
         show_a_new_favorite(eo)
         exit()
 

--- a/eo.py
+++ b/eo.py
@@ -31,6 +31,7 @@ import os
 import random
 import requests
 from scheduler import Scheduler
+import sys
 
 CREDENTIALS_FILE = ".credentials"
 USER_ENV_VAR = "EO_USER"
@@ -298,7 +299,9 @@ def main():
 
     eo = ElectricObject(username=credentials["username"], password=credentials["password"])
 
-    # demo(eo)
+    if sys.argv[1] == "--once":
+        show_a_new_favorite(eo)
+        exit()
 
     scheduler = Scheduler(SCHEDULE, lambda: show_a_new_favorite(eo), schedule_jitter=SCHEDULE_JITTER)
     scheduler.run()

--- a/eo.py
+++ b/eo.py
@@ -39,8 +39,8 @@ LOG_FILENAME = 'eo-python.log'
 LOG_SIZE = 1000000  # bytes
 LOG_NUM = 5  # number of rotating logs to keep
 
-# 24-hour time
-SCHEDULE = ["6:00", "12:00", "17:00", "22:00"]
+
+SCHEDULE = ["7:02", "12:02", "17:02", "22:02"]  # 24-hour time format
 SCHEDULE_JITTER = 10  # in minutes
 
 # The maximum number of favorites to consider for randomly displaying one.
@@ -246,12 +246,10 @@ def setup_logging():
     return logger
 
 
-def scheduled_fn(eo):
-    """
-
-    """
-    logger = logging.getLogger(__name__)
-    logger.info('updating favorite')
+def new_favorite(eo):
+    """Update the EO1 with a new, randomly selected favorite."""
+    logger = logging.getLogger("eo")
+    logger.info('Updating favorite')
     displayed = eo.display_random_favorite()
     if displayed:
         logger.info("Displayed artwork id " + str(displayed))
@@ -259,7 +257,7 @@ def scheduled_fn(eo):
 
 def demo(eo):
     """An example that displays a random favorite."""
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger("eo")
 
     displayed = eo.display_random_favorite()
     if displayed:
@@ -297,7 +295,7 @@ def main():
 
     # demo(eo)
 
-    scheduler = Scheduler(SCHEDULE, lambda: scheduled_fn(eo), SCHEDULE_JITTER)
+    scheduler = Scheduler(SCHEDULE, lambda: new_favorite(eo), schedule_jitter=SCHEDULE_JITTER)
     scheduler.run()
 
 

--- a/eo_api.py
+++ b/eo_api.py
@@ -7,6 +7,8 @@ import time
 # How often should we sign-in?
 SIGNIN_INTERVAL_IN_HOURS = 4  # hours
 
+USER_AGENT = "eo-python-client"
+
 
 class EO_API(object):
     """The API class provides functions for the Electric Objects API calls.
@@ -47,7 +49,9 @@ class EO_API(object):
         requests, the sign-in may expire after some time. So requests that fail should
         try signing in again.
         """
-        self.net.set_session(requests.Session())
+        new_session = requests.Session()
+        new_session.headers["User-Agent"] = USER_AGENT
+        self.net.set_session(new_session)
         payload = {
             "user[email]": self.username,
             "user[password]": self.password

--- a/eo_net.py
+++ b/eo_net.py
@@ -188,8 +188,9 @@ class EO_Net(object):
             jittered_delay = self.jitter(delay, JITTER_FACTOR)
 
             # retries + 1: Use natural numbers for readability.
-            self.logger.error("failed request {0} of {1}. Retrying in {2:.1f} seconds.".
-                              format(retries + 1, NUM_RETRIES + 1, jittered_delay))
+            self.logger.error(
+                "failed request {0} of {1} to URL '{2}'. Retrying in {3:.1f} seconds.".format(
+                    retries + 1, NUM_RETRIES + 1, url, jittered_delay))
 
             # Exponential backoff: Double the delay between each retry, or equivilently,
             #     delay = INITIAL_RETRY_DELAY * 2 ** retries
@@ -200,7 +201,8 @@ class EO_Net(object):
             retries += 1
             time.sleep(jittered_delay)
 
-        self.logger.error("maximum HTTP request attempts ({0}) exceeded.".format(NUM_RETRIES + 1))
+        self.logger.error("maximum HTTP request attempts ({0}) exceeded to URL '{1}'.".format(
+            NUM_RETRIES + 1, url))
         return None
 
     def make_request(self, url, params=None, method="GET", parse_json=False):

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,22 +1,94 @@
+import datetime
 import logging
+import random
+import sched
 import time
 
 
 class Scheduler(object):
+    """The Scheduler will execute a given function at preset times each day, with each time
+    jittered by +/- a given number of minutes.
 
-    def __init__(self, schedule, scheduled_fn, schedule_jitter=2):
-        """
+    The jitter feature allows the scheduler to run network access functions in a well-behaved way.
+    By slightly varying the scheduled times of functions that access external servers, we reduce
+    the probability that many clients will simultaneously make requests to the servers, overloading
+    them and leading to dropped requests.
+    """
+
+    def __init__(self, schedule, scheduled_fn, scheduled_fn_args=(), schedule_jitter=2):
+        """Initialize the scheduler object.
+
         Args:
             schedule: a list of times at which to run the function.
             scheduled_fn: the function to run at the given times.
+            scheduled_fn_args: args to be passed into the scheduled_fn, contained in a sequence.
+                For example,
+                    scheduler = Scheduler(SCHEDULE, new_favorite, (eo,), SCHEDULE_JITTER)
+                Note that this syntax also works:
+                    scheduler = Scheduler(SCHEDULE, lambda: new_favorite(eo), schedule_jitter=SCHEDULE_JITTER)
             schedule_jitter: the +/- number of minutes to randomize the scheduled times.
         """
-        self.logger = logging.getLogger('.'.join([__name__, self.__class__.__name__]))
+        self.logger = logging.getLogger(".".join(["eo", self.__class__.__name__]))
         self.scheduled_fn = scheduled_fn
+        self.scheduled_fn_args = scheduled_fn_args
+        self.jitter = schedule_jitter
+
+        self.scheduler = sched.scheduler(time.time, time.sleep)
+        self.ingest_schedule(schedule)
+
+    def ingest_schedule(self, schedule):
+        """Validate the schedule and store the events as time objects.
+        Args:
+            schedule: an array of strings of the form "HH:SS". These are the times, in 24 hour time
+            format, when the scheduler will call self.scheduled_fn.
+        """
+        self.schedule = []
+        for t in schedule:
+            try:
+                (h, m) = map(int, t.split(":"))
+                if h < 0 or h > 23 or m < 0 or m > 59:
+                    raise ValueError('invalid time in schedule: {0}. Skipping.'.format(t))
+                self.schedule.append(datetime.time(h, m))
+            except Exception as e:
+                self.logger.error(e)
+        self.schedule.sort()
+
+    def next_event_on_day(self, day):
+        """Return the next time in the schedule on the given day as an absolute date & time."""
+        time_now = datetime.datetime.now()
+        for t in self.schedule:
+            next_time = datetime.datetime.combine(day, t)
+            if next_time > time_now:
+                return next_time
+        return None
+
+    def next_event(self):
+        """Return the next time in the schedule, possibly tomorrow."""
+        today = datetime.date.today()
+        next_event = self.next_event_on_day(today)
+        if not next_event:
+            tomorrow = today + datetime.timedelta(days=1)
+            first = self.schedule[0]
+            next_event = datetime.datetime.combine(tomorrow, first)
+        return next_event
+
+    def add_jitter(self, atime):
+        """Add or subtract a random number of minutes to the given time, where the range of time is
+        +/- self.jitter. Return the jittered time.
+        """
+        offset = self.jitter * (2.0 * random.random() - 1.0)
+        return atime + datetime.timedelta(minutes=offset)
 
     def run(self):
-        self.logger.info("Now running the schedule.")
+        if not self.schedule:
+            self.logger.error("No valid schedule to run. Returning.")
+            return
+
         while True:
-            self.scheduled_fn()
-            self.logger.info("sleeping.")
-            time.sleep(20)
+            next_time = self.next_event()
+            next_time = self.add_jitter(next_time)  # Note: could move into the past.
+
+            self.logger.info("Next update: %s", next_time.strftime("%Y-%m-%d %H:%M:%S"))
+            next_t = time.mktime(next_time.timetuple())
+            self.scheduler.enterabs(next_t, 1, self.scheduled_fn, self.scheduled_fn_args)
+            self.scheduler.run()

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,22 @@
+import logging
+import time
+
+
+class Scheduler(object):
+
+    def __init__(self, schedule, scheduled_fn, schedule_jitter=2):
+        """
+        Args:
+            schedule: a list of times at which to run the function.
+            scheduled_fn: the function to run at the given times.
+            schedule_jitter: the +/- number of minutes to randomize the scheduled times.
+        """
+        self.logger = logging.getLogger('.'.join([__name__, self.__class__.__name__]))
+        self.scheduled_fn = scheduled_fn
+
+    def run(self):
+        self.logger.info("Now running the schedule.")
+        while True:
+            self.scheduled_fn()
+            self.logger.info("sleeping.")
+            time.sleep(20)


### PR DESCRIPTION
1. Updated the docs to explain the reliability best practices the code demonstrates: asynchrony, rate limiting, limited retries, exponential backoff, and jitter.
2. Added a scheduler. Now launchctl is no longer needed, which will be much simpler for most people. The scheduler uses of a list of daily times at which to display a new random favorite. More advanced schedules can still be created using launchctl. To use with launchctl, pass --once to the eo.py.
3. Bugfixes: 
   • added a credentials check.
   • don't log the artwork id that displayed if it didn't.

TODO (Gary): Update the docs.
